### PR TITLE
Bug Fix: issue with sacrifice reenabling after card played when card …

### DIFF
--- a/.godot/editor/script_editor_cache.cfg
+++ b/.godot/editor/script_editor_cache.cfg
@@ -91,11 +91,11 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 0,
+"column": 37,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 82,
-"scroll_position": 57.0,
+"row": 46,
+"scroll_position": 30.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }

--- a/CardAndDeckInterface.gd
+++ b/CardAndDeckInterface.gd
@@ -45,7 +45,8 @@ func _process(delta):
 
 func cardPressed(card:Card,cardNode:Node):
 	$"../Action Button".disabled = false
-	$"../Sacrifice Button".disabled = false
+	if $"../Action Button".text != "End Turn": #Works for disabling sacrifice without event cards being played may need to reevaluate then
+		$"../Sacrifice Button".disabled = false
 	if selectedCardNode != null:
 		selectedCardNode.button_pressed = false
 	selectedCardNode = cardNode


### PR DESCRIPTION
…is selected from hand

- added check to card pressed method to check if action button is not End Turn and if true enable sacrifice button (may need to be changed after event cards are implemented)