### PR TITLE
Changes to separate player from Path for planned multiplayer

### DIFF
--- a/.godot/editor/Hand.gd-folding-ecee7150e335d6d814209d0304eca82a.cfg
+++ b/.godot/editor/Hand.gd-folding-ecee7150e335d6d814209d0304eca82a.cfg
@@ -1,0 +1,3 @@
+[folding]
+
+sections_unfolded=PackedStringArray()

--- a/.godot/editor/editor_layout.cfg
+++ b/.godot/editor/editor_layout.cfg
@@ -8,7 +8,7 @@ dock_split_2=0
 dock_split_3=0
 dock_hsplit_1=0
 dock_hsplit_2=270
-dock_hsplit_3=-296
+dock_hsplit_3=-507
 dock_hsplit_4=0
 dock_3="Scene,Import"
 dock_4="FileSystem"
@@ -21,7 +21,7 @@ open_scenes=["res://player.tscn", "res://Boards/Board.tscn", "res://Boards/CardA
 [ScriptEditor]
 
 open_scripts=["res://Boards/Board.gd", "res://Cards/Util/Card.gd", "res://Boards/CardAndDeckInterface.gd", "res://Controls/CardButton.gd", "res://Cards/CollectableCards.gd", "res://Cards/Util/Deck.gd", "res://Cards/Decks.gd", "res://Cards/EventCards.gd", "res://GameComplete.gd", "res://Cards/Util/Hand.gd", "res://MainMenu.gd", "res://Cards/MovementCards.gd", "res://player.gd", "res://Cards/ToolCards.gd"]
-open_help=["Array", "BaseButton", "Callable", "Control", "Curve2D", "Dictionary", "ImageTexture", "Node", "Node2D", "Path2D", "SceneTree", "Signal", "TextureButton", "Variant"]
+open_help=["@GDScript", "Array", "BaseButton", "Callable", "Control", "Curve2D", "Dictionary", "ImageTexture", "Node", "Node2D", "PackedScene", "Path2D", "RectangleShape2D", "SceneTree", "Shape2D", "Signal", "Texture", "Texture2D", "TextureButton", "Variant"]
 script_split_offset=70
 list_split_offset=0
 

--- a/.godot/editor/filesystem_cache8
+++ b/.godot/editor/filesystem_cache8
@@ -1,13 +1,13 @@
 2a60927148abd1d33b818b535e306557
-::res://::1699449329
+::res://::1699619118
 export_presets.cfg::TextFile::-1::1699320387::0::1::::<><>::
 GameComplete.gd::GDScript::-1::1699318545::0::1::::<>Node2D<>::
-GameComplete.tscn::PackedScene::6832299799178986129::1699394828::0::1::::<><>::res://GameComplete.gd
+GameComplete.tscn::PackedScene::6832299799178986129::1699470077::0::1::::<><>::res://GameComplete.gd
 icon.svg::CompressedTexture2D::3833855046394519279::1698886711::1698886716::1::::<><>::
 MainMenu.gd::GDScript::-1::1699369752::0::1::::<>Node2D<>::
-MainMenu.tscn::PackedScene::2158524535933797333::1699394828::0::1::::<><>::res://MainMenu.gd
-player.gd::GDScript::-1::1699278028::0::1::::Player<>CharacterBody2D<>::
-player.tscn::PackedScene::8897988629244706298::1699394828::0::1::::<><>::res://player.gd<>uid://boskfe13au8lr
+MainMenu.tscn::PackedScene::2158524535933797333::1699470077::0::1::::<><>::res://MainMenu.gd
+player.gd::GDScript::-1::1699449364::0::1::::Player<>CharacterBody2D<>::
+player.tscn::PackedScene::8897988629244706298::1699470077::0::1::::<><>::res://player.gd<>uid://boskfe13au8lr
 ::res://assets/::1699051524
 campfire disabled.png::CompressedTexture2D::1565374296101553641::1699051508::1699051524::1::::<><>::
 campfire.png::CompressedTexture2D::4899597511542822044::1699016679::1699016682::1::::<><>::
@@ -86,11 +86,11 @@ Pressed.png::CompressedTexture2D::7983225020572913145::1699038145::1699038297::1
 ::res://assets/Cards/Tools/WATER/::1699038297
 Normal.png::CompressedTexture2D::8461540050733825164::1699037418::1699038297::1::::<><>::
 Pressed.png::CompressedTexture2D::4365628657408405003::1699037477::1699038297::1::::<><>::
-::res://Boards/::1699395062
-Board.gd::GDScript::-1::1699318545::0::1::::<>Node2D<>::
-Board.tscn::PackedScene::6011419182091548006::1699395062::0::1::::<><>::res://Boards/Board.gd<>uid://d37sifvl71gd5<>uid://dy1itqb3wtb67<>uid://buons7dyfdoh5
-CardAndDeckInterface.gd::GDScript::-1::1699395051::0::1::::<>HBoxContainer<>::
-CardAndDeckInterface.tscn::PackedScene::3819921996685721836::1699394828::0::1::::<><>::res://Boards/CardAndDeckInterface.gd<>uid://cb2nwjm8445j1<>uid://wkjqr05fbrvd<>uid://df5oto2vrsfe6<>uid://ctaj7sehr0cll
+::res://Boards/::1699470364
+Board.gd::GDScript::-1::1699470364::0::1::::<>Node2D<>::
+Board.tscn::PackedScene::6011419182091548006::1699470364::0::1::::<><>::res://Boards/Board.gd<>uid://d37sifvl71gd5<>uid://dy1itqb3wtb67<>uid://buons7dyfdoh5
+CardAndDeckInterface.gd::GDScript::-1::1699469746::0::1::::<>HBoxContainer<>::
+CardAndDeckInterface.tscn::PackedScene::3819921996685721836::1699470077::0::1::::<><>::res://Boards/CardAndDeckInterface.gd<>uid://cb2nwjm8445j1<>uid://wkjqr05fbrvd<>uid://df5oto2vrsfe6<>uid://ctaj7sehr0cll
 ::res://Cards/::1699393925
 CollectableCards.gd::GDScript::-1::1699393830::0::1::::CollectableCards<>Node<>::
 Decks.gd::GDScript::-1::1699393925::0::1::::Decks<>Node<>::

--- a/.godot/editor/filesystem_update4
+++ b/.godot/editor/filesystem_update4
@@ -1,8 +1,9 @@
-res://player.tscn
-res://player.gd
-res://Boards/Board.gd
 res://Boards/Board.tscn
+res://Boards/Board.gd
+res://Boards/CardAndDeckInterface.gd
+res://player.tscn
 res://Boards/CardAndDeckInterface.tscn
 res://GameComplete.tscn
 res://MainMenu.tscn
-res://Boards/CardAndDeckInterface.gd
+res://Cards/Util/Hand.gd
+res://player.gd

--- a/.godot/editor/player.tscn-folding-36a25e342948d0ceacc500772b5412b3.cfg
+++ b/.godot/editor/player.tscn-folding-36a25e342948d0ceacc500772b5412b3.cfg
@@ -1,5 +1,5 @@
 [folding]
 
-node_unfolds=[NodePath("."), PackedStringArray("Transform")]
+node_unfolds=[NodePath("."), PackedStringArray("Transform"), NodePath("CollisionShape2D"), PackedStringArray("Transform", "shape"), NodePath("Sprite2D"), PackedStringArray("Offset", "Transform", "texture")]
 resource_unfolds=["res://player.tscn::RectangleShape2D_may4g", PackedStringArray()]
 nodes_folded=[]

--- a/.godot/editor/project_metadata.cfg
+++ b/.godot/editor/project_metadata.cfg
@@ -12,7 +12,7 @@ run_reload_scripts=true
 [recent_files]
 
 scenes=["res://MainMenu.tscn", "res://GameComplete.tscn", "res://Boards/CardAndDeckInterface.tscn", "res://Boards/Board.tscn", "res://player.tscn", "res://CardAndDeckInterface.tscn", "res://Board.tscn"]
-scripts=["Curve2D", "Path2D", "Node2D", "Variant", "TextureButton", "Signal", "SceneTree", "Node", "ImageTexture", "Dictionary"]
+scripts=["Texture2D", "Texture", "RectangleShape2D", "Shape2D", "@GDScript", "PackedScene", "Variant", "TextureButton", "Signal", "SceneTree"]
 
 [script_setup]
 

--- a/.godot/editor/script_editor_cache.cfg
+++ b/.godot/editor/script_editor_cache.cfg
@@ -3,10 +3,10 @@
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 12,
+"column": 23,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 8,
+"row": 18,
 "scroll_position": 0.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
@@ -45,11 +45,11 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 15,
+"column": 60,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 60,
-"scroll_position": 25.0,
+"row": 52,
+"scroll_position": 0.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }
@@ -59,11 +59,11 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 13,
+"column": 36,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 8,
-"scroll_position": 0.0,
+"row": 104,
+"scroll_position": 86.0,
 "selection": false,
 "syntax_highlighter": "GDScript"
 }
@@ -161,10 +161,10 @@ state={
 state={
 "bookmarks": PackedInt32Array(),
 "breakpoints": PackedInt32Array(),
-"column": 0,
+"column": 1,
 "folded_lines": Array[int]([]),
 "h_scroll_position": 0,
-"row": 16,
+"row": 8,
 "scroll_position": 0.0,
 "selection": false,
 "syntax_highlighter": "GDScript"

--- a/.godot/global_script_class_cache.cfg
+++ b/.godot/global_script_class_cache.cfg
@@ -41,6 +41,12 @@ list=Array[Dictionary]([{
 "language": &"GDScript",
 "path": "res://Cards/Util/Hand.gd"
 }, {
+"base": &"HBoxContainer",
+"class": &"HandUi",
+"icon": "",
+"language": &"GDScript",
+"path": "res://Boards/CardAndDeckInterface.gd"
+}, {
 "base": &"Node",
 "class": &"MovementCards",
 "icon": "",

--- a/Boards/Board.gd
+++ b/Boards/Board.gd
@@ -10,20 +10,24 @@ var boardPositionsCount:int = 0
 @onready var path = $Path2D
 @onready var pathFollow = $Path2D/PathFollow2D
 
-@onready var player:PackedScene = load("res://player.tscn")
-@onready var currentPlayer
+@onready var player:Node = Player.new(Hand.new(Deck.new([])))
+@onready var playerInstantiation
+@onready var currentPlayer:Player
+@onready var handUi:HandUi = HandUi.new()
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	boardPositionsCount =$Path2D.curve.point_count
-	#print_debug($Player.position)
-	print_debug(path.curve.get_point_position(0))
-	currentPlayer  = player.instantiate()
-	self.add_child(currentPlayer)
+	player.set_name("Player_1")
+	self.add_child(player)
+	
+	currentPlayer = player 
 	currentPlayer.global_position = path.curve.get_point_position(0) + path.global_position
-	#playerNode.Player.points
-	#var pathDup = path.duplicate()
-	#self.add_child(pathDup)
-	#pathFollow.add_child(player.instantiate())
+	var retunedHandAndDeck:Dictionary = Hand.new(Deck.new([])).drawHand(0, deck)
+	deck = retunedHandAndDeck["DECK"]
+	currentPlayer.hand = Hand.new(retunedHandAndDeck["HAND"])
+	handUi.buildHandUi(currentPlayer.hand.hand)
+
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _physics_process(delta):

--- a/Boards/CardAndDeckInterface.gd
+++ b/Boards/CardAndDeckInterface.gd
@@ -1,4 +1,5 @@
 extends HBoxContainer
+class_name HandUi
 
 @onready var board:Node = $"../.."
 @onready var deck:Deck = board.deck
@@ -14,7 +15,7 @@ var selectedCardNode:Node
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	
-	var retunedHandAndDeck:Dictionary = Hand.new().drawHand(0, deck)
+	var retunedHandAndDeck:Dictionary = Hand.new(Deck.new([])).drawHand(0, deck)
 	deck = retunedHandAndDeck["DECK"]
 	hand = retunedHandAndDeck["HAND"]
 	buildHandUi(hand)
@@ -103,7 +104,7 @@ func executeCounterCardPlayed():
 func executeEndTurn():
 	$"../Action Button".disabled = true
 	$"../EventCardVisual".texture = null
-	while hand.deck.size()< Hand.new().minHandSize:
+	while hand.deck.size()< Hand.new(Deck.new([])).minHandSize:
 		drawCard(hand,deck)
 	redrawHand(hand)
 	$"../Action Button".text = "Play Card"

--- a/Cards/Util/Hand.gd
+++ b/Cards/Util/Hand.gd
@@ -4,6 +4,9 @@ class_name Hand
 var hand:Deck=Deck.new([])
 var minHandSize:int = 7
 
+func _init(handDeck:Deck):
+	hand = handDeck
+	
 func drawHand(handSize:int,deck:Deck):
 	if handSize == 0:
 		handSize = minHandSize

--- a/player.gd
+++ b/player.gd
@@ -6,6 +6,17 @@ var playerPosition:int = 0
 var points:int = 0
 
 func _init(hand:Hand):
+	var collisionShape:CollisionShape2D = CollisionShape2D.new()
+	var rectangleShape:RectangleShape2D = RectangleShape2D.new()
+	rectangleShape.size = Vector2(8,8)
+	collisionShape.shape = rectangleShape
+	collisionShape.position = Vector2(-4,-4)
+	self.add_child(collisionShape)
+	var sprite:Sprite2D = Sprite2D.new()
+	sprite.texture = load("res://assets/HikerTemp.png")
+	sprite.position = Vector2(-4,-4)
+	sprite.scale = Vector2(0.016,0.016)
+	self.add_child(sprite)
 	hand = hand
 	
 func play_Turn():


### PR DESCRIPTION
- Player now created on board load
- player hand is now set when the board is loaded
- turn functions are using the current players hand (may need some changes when multiplayer introduced)
- Player movement is separate from the path and now only references the path so multiple players can follow the same path
- player object now creates associated sprite and collision shape when initiated